### PR TITLE
Import hackage package set from haskell.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,30 @@
-{ pkgs ? import <nixpkgs> {} }:
 let
-  hsPkgs = import ./pkgs.nix { inherit pkgs; };
+  overrideWith = override: default:
+   let
+     try = builtins.tryEval (builtins.findFile builtins.nixPath override);
+   in if try.success then
+     builtins.trace "using search host <${override}>" try.value
+   else
+     default;
 in
-    hsPkgs // {
-      nix-tools-all-execs = pkgs.symlinkJoin
-        { name = "nix-tools";
-          paths = builtins.attrValues hsPkgs.nix-tools.components.exes; };
-    }
+
+{ pkgs ? import <nixpkgs> {}
+
+# a different haskell infrastructure
+, haskell ? import (overrideWith "haskell"
+                     (pkgs.fetchFromGitHub { owner  = "input-output-hk";
+                                             repo   = "haskell.nix";
+                                             rev    = "ed1dbc01f98411894f6613c62818f14b02fb6679";
+                                             sha256 = "0kbj4kb9rlvjb4afpcisz9zlk5z3h7frkwggfwri1q5683fapkgv";
+                                             name   = "haskell-lib-source"; }))
+                   { inherit pkgs; }
+}:
+
+let
+  hsPkgs = import ./pkgs.nix { inherit (haskell) mkPkgSet; };
+in
+  hsPkgs // {
+    nix-tools-all-execs = pkgs.symlinkJoin
+      { name = "nix-tools";
+        paths = builtins.attrValues hsPkgs.nix-tools.components.exes; };
+  }

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,31 +1,6 @@
-{ pkgs ? import <nixpkgs> {}
-}:
+{ mkPkgSet }:
+
 let
-  overrideWith = override: default:
-   let
-     try = builtins.tryEval (builtins.findFile builtins.nixPath override);
-   in if try.success then
-     builtins.trace "using search host <${override}>" try.value
-   else
-     default;
-in
-let
-  # all packages from hackage as nix expressions
-  hackage = import (overrideWith "hackage"
-                   (pkgs.fetchFromGitHub { owner  = "angerman";
-                                           repo   = "hackage.nix";
-                                           rev    = "15155a37d3a40173b57e93b09453984fac614523";
-                                           sha256 = "016538bfnlb0dxdga4n5p0m75zq0zymbdh5vrvr0gwsa7pywi7zy";
-                                           name   = "hackage-exprs-source"; }))
-                   ;
-  # a different haskell infrastructure
-  haskell = import (overrideWith "haskell"
-                    (pkgs.fetchFromGitHub { owner  = "angerman";
-                                            repo   = "haskell.nix";
-                                            rev    = "ed1dbc01f98411894f6613c62818f14b02fb6679";
-                                            sha256 = "0kbj4kb9rlvjb4afpcisz9zlk5z3h7frkwggfwri1q5683fapkgv";
-                                            name   = "haskell-lib-source"; }))
-                   hackage;
 
   # our packages
   # this is generated with plan-to-nix
@@ -33,8 +8,7 @@ let
   # $ plan-to-nix ./dist-newstyle/cache/plan.json > plan.nix
   plan = import ./plan.nix;
 
-  pkgSet = haskell.mkNewPkgSet {
-    inherit pkgs;
+  pkgSet = mkPkgSet {
     pkg-def = plan;
     pkg-def-overlays = [
       { nix-tools  = ./nix-tools.nix;


### PR DESCRIPTION
The Hackage Nix expressions will come from `haskell.nix` as of input-output-hk/haskell.nix#47.
