### PR TITLE
Allow traling file size after revision SHA256 for Stack deps

### DIFF
--- a/stack2nix/Stack2nix/Stack.hs
+++ b/stack2nix/Stack2nix/Stack.hs
@@ -135,6 +135,8 @@ data Location
 -- Parsers for package indices
 sha256Suffix :: ReadP r Sha256
 sha256Suffix = string "@sha256:" *> many1 (satisfy (`elem` (['0'..'9']++['a'..'z']++['A'..'Z'])))
+                                 -- Stack supports optional cabal file size after revision's SHA value,
+                                 -- we parse it but it doesn't get used
                                  <* optional (char ',' <* many1 (satisfy isDigit))
 
 revSuffix :: ReadP r CabalRev

--- a/stack2nix/Stack2nix/Stack.hs
+++ b/stack2nix/Stack2nix/Stack.hs
@@ -15,6 +15,7 @@ module Stack2nix.Stack
   , StackSnapshot(..)
   ) where
 
+import Data.Char (isDigit)
 import Data.List (isSuffixOf)
 import qualified Data.Text as T
 import Data.Aeson
@@ -134,6 +135,7 @@ data Location
 -- Parsers for package indices
 sha256Suffix :: ReadP r Sha256
 sha256Suffix = string "@sha256:" *> many1 (satisfy (`elem` (['0'..'9']++['a'..'z']++['A'..'Z'])))
+                                 <* optional (char ',' <* many1 (satisfy isDigit))
 
 revSuffix :: ReadP r CabalRev
 revSuffix = string "@rev:" *> (read <$> many1 (satisfy (`elem` ['0'..'9'])))


### PR DESCRIPTION
I was added 1.5 years ago in https://github.com/commercialhaskell/stack/commit/cc92bd6b181ef59c595cc16bc152118e64c7f18c but somehow it didn't appear in Stack's changelog or documentation