### PR TITLE
Use revisions with prefix "r" as hackage.nix does

### DIFF
--- a/stack2nix/Stack2nix/Stack.hs
+++ b/stack2nix/Stack2nix/Stack.hs
@@ -90,9 +90,14 @@ type Resolver = String
 type Name     = String
 type Compiler = String
 type Sha256   = String
-type CabalRev = Int    -- cabal revision 0,1,2,...
+newtype CabalRev = CabalRev Int -- cabal revision 0,1,2,...
+ deriving (Show)
 type URL      = String -- Git/Hg/... URL
 type Rev      = String -- Git revision
+
+instance Text CabalRev where
+  disp (CabalRev rev) = "r" <> disp rev
+  parse = char 'r' *> (CabalRev <$> parse)
 
 --------------------------------------------------------------------------------
 -- Data Types
@@ -136,7 +141,7 @@ sha256Suffix :: ReadP r Sha256
 sha256Suffix = string "@sha256:" *> many1 (satisfy (`elem` (['0'..'9']++['a'..'z']++['A'..'Z'])))
 
 revSuffix :: ReadP r CabalRev
-revSuffix = string "@rev:" *> (read <$> many1 (satisfy (`elem` ['0'..'9'])))
+revSuffix = string "@rev:" *> (CabalRev . read <$> many1 (satisfy (`elem` ['0'..'9'])))
 
 suffix :: ReadP r (Maybe (Either Sha256 CabalRev))
 suffix = option Nothing (Just <$> (Left <$> sha256Suffix) +++ (Right <$> revSuffix))


### PR DESCRIPTION
The current output from `stack-to-nix` isn't correct and this fixes it