### PR TITLE
Option to ignore package.yaml

### DIFF
--- a/stack2nix/Stack2nix.hs
+++ b/stack2nix/Stack2nix.hs
@@ -114,7 +114,7 @@ packages2nix args (Stack _ _ pkgs) =
   do cwd <- getCurrentDirectory
      fmap (mkNonRecSet . concat) . forM pkgs $ \case
        (LocalPath folder) ->
-         do cabalFiles <- findCabalFiles (dropFileName (argStackYaml args) </> folder)
+         do cabalFiles <- findCabalFiles (argHpackUse args) (dropFileName (argStackYaml args) </> folder)
             forM cabalFiles $ \cabalFile ->
               let pkg = cabalFilePkgName cabalFile
                   nix = pkg <.> "nix"
@@ -147,7 +147,7 @@ packages2nix args (Stack _ _ pkgs) =
         cabalFromPath url rev subdir path = do
           d <- liftIO $ doesDirectoryExist path
           unless d $ fail ("not a directory: " ++ path)
-          cabalFiles <- liftIO $ findCabalFiles path
+          cabalFiles <- liftIO $ findCabalFiles (argHpackUse args) path
           return $ \sha256 ->
             forM cabalFiles $ \cabalFile -> do
             let pkg = cabalFilePkgName cabalFile

--- a/stack2nix/Stack2nix/CLI.hs
+++ b/stack2nix/Stack2nix/CLI.hs
@@ -1,17 +1,23 @@
 module Stack2nix.CLI
   ( Args(..)
+  , HpackUse(..)
   , parseStack2nixArgs
   ) where
 
 import Options.Applicative hiding (option)
 import Data.Semigroup ((<>))
 
+data HpackUse
+  = IgnorePackageYaml
+  | UsePackageYamlFirst
+  deriving Show
 
 --------------------------------------------------------------------------------
 -- CLI Arguments
 data Args = Args
   { argOutputDir :: FilePath
   , argStackYaml :: FilePath
+  , argHpackUse  :: HpackUse
   , argCacheFile :: FilePath
   } deriving Show
 
@@ -20,6 +26,7 @@ args :: Parser Args
 args = Args
   <$> strOption ( long "output" <> short 'o' <> metavar "DIR" <> help "Generate output in DIR" )
   <*> strOption ( long "stack-yaml" <> value "stack.yaml" <> showDefault <> metavar "FILE" <> help "Override project stack.yaml" )
+  <*> flag UsePackageYamlFirst IgnorePackageYaml (long "ignore-package-yaml" <> help "disable hpack run and use only cabal disregarding package.yaml existence")
   <*> strOption ( long "cache" <> value ".stack-to-nix.cache" <> showDefault <> metavar "FILE" <> help "Dependency cache file" )
 
 parseStack2nixArgs :: IO Args

--- a/stack2nix/Stack2nix/Project.hs
+++ b/stack2nix/Stack2nix/Project.hs
@@ -12,7 +12,6 @@ import System.FilePath ((</>))
 import System.Directory (listDirectory, doesFileExist)
 import Data.List (isSuffixOf)
 
-import qualified Hpack
 import qualified Hpack.Config as Hpack
 import qualified Hpack.Render as Hpack
 

--- a/stack2nix/Stack2nix/Project.hs
+++ b/stack2nix/Stack2nix/Project.hs
@@ -18,9 +18,12 @@ import qualified Hpack.Render as Hpack
 
 import Cabal2Nix (CabalFile(..), CabalFileGenerator(..))
 
-findCabalFiles :: FilePath -> IO [CabalFile]
-findCabalFiles path = doesFileExist (path </> Hpack.packageConfig) >>= \case
-  False -> fmap (OnDisk . (path </>)) . filter (isSuffixOf ".cabal") <$> listDirectory path
+import Stack2nix.CLI (HpackUse(..))
+
+findCabalFiles :: HpackUse -> FilePath -> IO [CabalFile]
+findCabalFiles IgnorePackageYaml path = findOnlyCabalFiles path
+findCabalFiles UsePackageYamlFirst path = doesFileExist (path </> Hpack.packageConfig) >>= \case
+  False -> findOnlyCabalFiles path
   True -> do
     mbPkg <- Hpack.readPackageConfig Hpack.defaultDecodeOptions {Hpack.decodeOptionsTarget = path </> Hpack.packageConfig}
     case mbPkg of
@@ -32,3 +35,6 @@ findCabalFiles path = doesFileExist (path </> Hpack.packageConfig) >>= \case
 
   where encodeUtf8 :: String -> ByteString
         encodeUtf8 = T.encodeUtf8 . T.pack
+
+findOnlyCabalFiles :: FilePath -> IO [CabalFile]
+findOnlyCabalFiles path = fmap (OnDisk . (path </>)) . filter (isSuffixOf ".cabal") <$> listDirectory path


### PR DESCRIPTION
This more or less follows feature I added to cabal2nix in https://github.com/NixOS/cabal2nix/pull/403 - sometimes package comes with a `package.yaml` even from Hackage but we don't want to run `hpack` on it and just use what cabal file contains