### PR TITLE
Use root package by default for Stack

### DIFF
--- a/stack2nix/Stack2nix/Stack.hs
+++ b/stack2nix/Stack2nix/Stack.hs
@@ -165,7 +165,7 @@ instance FromJSON Stack where
   parseJSON = withObject "Stack" $ \s -> Stack
     <$> s .: "resolver"
     <*> s .:? "compiler" .!= Nothing
-    <*> ((<>) <$> s .:? "packages"   .!= []
+    <*> ((<>) <$> s .:? "packages"   .!= [LocalPath "."]
               <*> s .:? "extra-deps" .!= [])
 
 instance FromJSON StackSnapshot where


### PR DESCRIPTION
`packages` is optional in `stack.yaml` but if I try `stack-to-nix` on such a project I get a failure:
```
stack-to-nix: nix/pkgs.nix: openFile: does not exist (No such file or directory)
```