### PR TITLE
Fix build and import haskell.nix override

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,23 +1,14 @@
-let
-  overrideWith = override: default:
-   let
-     try = builtins.tryEval (builtins.findFile builtins.nixPath override);
-   in if try.success then
-     builtins.trace "using search host <${override}>" try.value
-   else
-     default;
-in
-
 { pkgs ? import <nixpkgs> {}
 
 # a different haskell infrastructure
-, haskell ? import (overrideWith "haskell"
-                     (pkgs.fetchFromGitHub { owner  = "input-output-hk";
-                                             repo   = "haskell.nix";
-                                             rev    = "3584345a9ab001d1867e972a1a20b4406cbffd68";
-                                             sha256 = "08pzfvspfl5nvn5szy7bv3rbwymjgmbdm1ac571c64fzhrwf5ghw";
-                                             name   = "haskell-lib-source"; }))
-                   { inherit pkgs; }
+, haskell ? import haskellLibSrc { inherit pkgs; }
+, haskellLibSrc ? pkgs.fetchFromGitHub {
+    owner  = "input-output-hk";
+    repo   = "haskell.nix";
+    rev    = "0de60e8b0cd0338b82d25d6148246d1cdbf37a47";
+    sha256 = "0j3mjlzwg8f95rsnj1vrcyivil65is16i48l1c3czm0ps39frch9";
+    name   = "haskell-lib-source";
+  }
 }:
 
 let

--- a/nix/.plan-pkgs.nix
+++ b/nix/.plan-pkgs.nix
@@ -369,7 +369,7 @@
           };
         };
       };
-  overlay = hackage:
+  extras = hackage:
     {
       packages = {
         nix-tools = ./.plan.nix/nix-tools.nix;


### PR DESCRIPTION
There was still some breakage due to `overlay` → `extras`. The haskell.nix revision needed to be updated.

I removed the `overrideWith` because it's not necessary here. The haskell lib can be overridden with normal function args.