### PR TITLE
hackage2nix: switch to json output

### DIFF
--- a/nix-tools.cabal
+++ b/nix-tools.cabal
@@ -127,11 +127,14 @@ executable hackage-to-nix
                      , hackage-db
                      , hnix
                      , Cabal
+                     , aeson
+                     , aeson-pretty
                      , containers
                      , bytestring
                      , text
                      , cryptohash-sha256
                      , base16-bytestring
+                     , base64-bytestring
                      , filepath
                      , directory
                      , transformers


### PR DESCRIPTION
This decreases hackage.nix loading time by approximately 5x (from 1.6s to 0.3s),
dropping my evaluation time from 8s to 6s in total (todo: is hackage.nix imported multiple times somehow?). It would be nicer to keep the old mode of operation intact, but this will be hard without a lot of code duplication.