### PR TITLE
Include cabal-version field into cabal files generated with hpack

### DIFF
--- a/cabal2nix/Main.hs
+++ b/cabal2nix/Main.hs
@@ -92,10 +92,17 @@ findCabalFiles path = doesFileExist (path </> Hpack.packageConfig) >>= \case
       Right r ->
         return $ [InMemory (Just Hpack)
                            (Hpack.decodeResultCabalFile r)
-                           (encodeUtf8 $ Hpack.renderPackage [] (Hpack.decodeResultPackage r))]
+                           (encodeUtf8 $ render r)]
 
-  where encodeUtf8 :: String -> ByteString
-        encodeUtf8 = T.encodeUtf8 . T.pack
+  where
+    render :: Hpack.DecodeResult -> String
+    render r =
+      let body = Hpack.renderPackage [] (Hpack.decodeResultPackage r)
+          cabalVersion = Hpack.decodeResultCabalVersion r
+      in cabalVersion ++ body
+
+    encodeUtf8 :: String -> ByteString
+    encodeUtf8 = T.encodeUtf8 . T.pack
 
 
 expr :: FilePath -> String -> String -> IO (Binding NExpr)

--- a/lib/Stack2nix/Project.hs
+++ b/lib/Stack2nix/Project.hs
@@ -30,10 +30,18 @@ findCabalFiles UsePackageYamlFirst path = doesFileExist (path </> Hpack.packageC
       Right r ->
         return $ [InMemory (Just Hpack)
                            (Hpack.decodeResultCabalFile r)
-                           (encodeUtf8 $ Hpack.renderPackage [] (Hpack.decodeResultPackage r))]
+                           (encodeUtf8 $ render r)]
 
-  where encodeUtf8 :: String -> ByteString
-        encodeUtf8 = T.encodeUtf8 . T.pack
+  where
+    render :: Hpack.DecodeResult -> String
+    render r =
+      let body = Hpack.renderPackage [] (Hpack.decodeResultPackage r)
+          cabalVersion = Hpack.decodeResultCabalVersion r
+      in cabalVersion ++ body
+
+    encodeUtf8 :: String -> ByteString
+    encodeUtf8 = T.encodeUtf8 . T.pack
+
 
 findOnlyCabalFiles :: FilePath -> IO [CabalFile]
 findOnlyCabalFiles path = fmap (OnDisk . (path </>)) . filter (isSuffixOf ".cabal") <$> listDirectory path

--- a/plan2nix/Plan2Nix/Project.hs
+++ b/plan2nix/Plan2Nix/Project.hs
@@ -28,7 +28,14 @@ findCabalFiles path = doesFileExist (path </> Hpack.packageConfig) >>= \case
       Right r ->
         return $ [InMemory (Just Hpack)
                            (Hpack.decodeResultCabalFile r)
-                           (encodeUtf8 $ Hpack.renderPackage [] (Hpack.decodeResultPackage r))]
+                           (encodeUtf8 $ render r)]
 
-  where encodeUtf8 :: String -> ByteString
-        encodeUtf8 = T.encodeUtf8 . T.pack
+  where
+    render :: Hpack.DecodeResult -> String
+    render r =
+      let body = Hpack.renderPackage [] (Hpack.decodeResultPackage r)
+          cabalVersion = Hpack.decodeResultCabalVersion r
+      in cabalVersion ++ body
+
+    encodeUtf8 :: String -> ByteString
+    encodeUtf8 = T.encodeUtf8 . T.pack


### PR DESCRIPTION
When you run hpack from the command line, it puts `cabal-version` into generated cabal file, in addition to the result of `renderPackage` function. This field defines which features the cabal file may use, and may also affect parsing. For example, parsing of the `license` field depends on `cabal-version`: https://github.com/haskell/cabal/pull/5050, so without it cabal will fail to parse generated file for a `package.yaml` like this:

```yaml
name: example
version: 1
license: LicenseRef-Custom
library:
  dependencies:
    - base
```

This PR makes sure this field is included when hpack is used