### PR TITLE
Cabal 3.2 support

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -20,6 +20,9 @@ echo "+++ Run stable version of plan-to-nix"
 nix build '(let haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}; in (import haskellNix.sources.nixpkgs-default haskellNix.nixpkgsArgs).haskell-nix.nix-tools)' -o nt
 ./nt/bin/plan-to-nix --output .buildkite/nix1 --plan-json dist-newstyle/cache/plan.json
 
+# Replace currently broken plan-to-nix output
+cp .buildkite/fixed.nix .buildkite/nix1/default.nix
+
 echo
 echo "+++ Build project"
 nix build -f .buildkite/nix1 nix-tools.components.exes --no-link

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -60,7 +60,10 @@ nix build -f .buildkite/nix2 nix-tools.components.exes --no-link
 echo
 echo "--- Test index file truncation"
 
+shopt -s nullglob
 for a in /nix/store/*-00-index.tar.gz; do nix-store --delete $a; done
+shopt -u nullglob
+
 nix build -f test/truncate-index.nix --no-link \
     --arg nix-tools-path ./.buildkite/nix2  \
     --argstr index-state "$index_state" \

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -17,7 +17,7 @@ cabal new-configure
 
 echo
 echo "+++ Run stable version of plan-to-nix"
-nix build '(let haskellNix = builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz"; in (import (haskellNix + "/nixpkgs") (import haskellNix)).haskell-nix.nix-tools)' -o nt
+nix build '(let haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}; in (import haskellNix.sources.nixpkgs-default haskellNix.nixpkgsArgs).haskell-nix.nix-tools)' -o nt
 ./nt/bin/plan-to-nix --output .buildkite/nix1 --plan-json dist-newstyle/cache/plan.json
 
 echo

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -I "nixpkgs=channel:nixos-19.09" --pure -i bash -p nix cabal-install ghc git nix-prefetch-git cacert
+#! nix-shell -I "nixpkgs=channel:nixos-20.03" --pure -i bash -p nix cabal-install ghc git nix-prefetch-git cacert
 
-export NIX_PATH="nixpkgs=channel:nixos-19.09"
+export NIX_PATH="nixpkgs=channel:nixos-20.03"
 index_state="2020-01-10T00:00:00Z"
 expected_hash="0z2jc4fibfxz88pfgjq3wk5j3v7sn34xkwb8h60hbwfwhhy63vx6"
 
@@ -12,7 +12,7 @@ set -euo pipefail
 rm -f .nix-tools.cache
 
 echo "+++ Cabal configure"
-cabal new-update "hackage.haskell.org,$index_state"
+cabal new-update
 cabal new-configure
 
 echo
@@ -34,8 +34,8 @@ echo "There are no tests -- https://github.com/input-output-hk/haskell.nix/issue
 echo
 echo "+++ Add runtime dependencies to PATH"
 
-nix build -f channel:nixos-19.03 nix-prefetch-scripts -o nix-prefetch-scripts
-nix build -f channel:nixos-19.03 git -o git
+nix build -f channel:nixos-20.03 nix-prefetch-scripts -o nix-prefetch-scripts
+nix build -f channel:nixos-20.03 git -o git
 export PATH="$PWD/nix-prefetch-scripts/bin:$PWD/git/bin:$PATH"
 
 echo
@@ -47,6 +47,10 @@ rm -f .nix-tools.cache
 
 nix build -f .buildkite/nix1 nix-tools.components.exes.plan-to-nix
 ./result/bin/plan-to-nix --output .buildkite/nix2 --plan-json dist-newstyle/cache/plan.json
+
+# Add module needed to allow Cabal 3.2 to be installed
+sed -i -e 's|modules = \[\]|modules = \[{ nonReinstallablePkgs = \[ "rts" "ghc-heap" "ghc-prim" "integer-gmp" "integer-simple" "base" "deepseq" "array" "ghc-boot-th" "pretty" "template-haskell" "ghcjs-prim" "ghcjs-th" "ghc-boot" "ghc" "Win32" "array" "binary" "bytestring" "containers" "directory" "filepath" "ghc-boot" "ghc-compact" "ghc-prim" "hpc" "mtl" "parsec" "process" "text" "time" "transformers" "unix" "xhtml" "stm" "terminfo" \]; }\]|' \
+  .buildkite/nix2/default.nix
 
 echo
 echo "+++ Build project"

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -60,7 +60,7 @@ nix build -f .buildkite/nix2 nix-tools.components.exes --no-link
 echo
 echo "--- Test index file truncation"
 
-find /nix/store/ -name "*-00-index.tar.gz" -exec nix-store --delete {} \;
+for a in /nix/store/*-00-index.tar.gz; do nix-store --delete $a; done
 nix build -f test/truncate-index.nix --no-link \
     --arg nix-tools-path ./.buildkite/nix2  \
     --argstr index-state "$index_state" \

--- a/.buildkite/fixed.nix
+++ b/.buildkite/fixed.nix
@@ -7,7 +7,21 @@ let
   pkgSet = pkgs.haskell-nix.mkCabalProjectPkgSet {
     plan-pkgs = import ./pkgs.nix;
     pkg-def-extras = [];
-    modules = [];
+    modules = [{
+     nonReinstallablePkgs= [ "rts" "ghc-heap" "ghc-prim" "integer-gmp" "integer-simple" "base"
+      "deepseq" "array" "ghc-boot-th" "pretty" "template-haskell"
+      # ghcjs custom packages
+      "ghcjs-prim" "ghcjs-th"
+      "ghc-boot"
+      "ghc" "Win32" "array" "binary" "bytestring" "containers"
+      "directory" "filepath" "ghc-boot" "ghc-compact" "ghc-prim"
+      # "ghci" "haskeline"
+      "hpc"
+      "mtl" "parsec" "process" "text" "time" "transformers"
+      "unix" "xhtml"
+      # "stm" "terminfo"
+     ];
+    }];
   };
 
 in

--- a/.buildkite/fixed.nix
+++ b/.buildkite/fixed.nix
@@ -1,0 +1,14 @@
+{ haskellNix ? import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz) {}
+, nixpkgs ? haskellNix.sources.nixpkgs-default }:
+
+let
+  pkgs = import nixpkgs haskellNix.nixpkgsArgs;
+
+  pkgSet = pkgs.haskell-nix.mkCabalProjectPkgSet {
+    plan-pkgs = import ./pkgs.nix;
+    pkg-def-extras = [];
+    modules = [];
+  };
+
+in
+  pkgSet.config.hsPkgs

--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,6 @@
-index-state: 2020-04-12T00:00:00Z
+index-state: 2020-05-03T00:00:00Z
 
 packages: .
-
--- Needs https://github.com/input-output-hk/iohk-nix/commit/6a8c29117eff36ce975e02e01efc8b25d93fcb90#diff-6fb0c6517b547a8baf082d5d2d604842
--- to work with the data-dir issues when building components.
-
-constraints: hnix >= 0.6.1
 
 source-repository-package
     type: git
@@ -13,8 +8,6 @@ source-repository-package
     tag: f1f528db7b02d90e9953297c716de5e046f3570f
     --sha256: 0j86xkpndxn41sy2mchx029zc3isaxh61hdvnakpiflkcmfaji1w
 
-source-repository-package
-    type: git
-    location: https://github.com/galenhuntington/haskell-src-meta.git
-    tag: 109ee29d5fd0f4e23fdd2f80eb122d66341b64a9
-    --sha256: 08qw6y9br6fy3qkwl9v2kp38msprsq9v1ssym0fsnj2jm0vbnfrx
+-- hnix requires hnix-store-core < 0.2, however hnix-store-core-0.1 breaks
+-- plan construction.
+allow-newer: hnix-store-core

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-01-10T00:00:00Z
+index-state: 2020-04-12T00:00:00Z
 
 packages: .
 
@@ -9,9 +9,9 @@ constraints: hnix >= 0.6.1
 
 source-repository-package
     type: git
-    location: https://github.com/ElvishJerricco/hackage-db.git
-    tag: 84ca9fc75ad45a71880e938e0d93ea4bde05f5bd
-    --sha256: 0y3kw1hrxhsqmyx59sxba8npj4ya8dpgjljc21gkgdvdy9628q4c
+    location: https://github.com/hamishmack/hackage-db.git
+    tag: f1f528db7b02d90e9953297c716de5e046f3570f
+    --sha256: 0j86xkpndxn41sy2mchx029zc3isaxh61hdvnakpiflkcmfaji1w
 
 source-repository-package
     type: git

--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@
     }
 , nixpkgs ? (import haskellNixSrc {}).sources.nixpkgs-default
 , pkgs ? import nixpkgs (import haskellNixSrc {}).nixpkgsArgs
-, haskellCompiler ? "ghc865"
+, haskellCompiler ? "ghc883"
 }:
 let
   project = pkgs.haskell-nix.cabalProject {

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 { haskellNixSrc ? builtins.fetchTarball {
-      url = "https://github.com/input-output-hk/haskell.nix/archive/fc31134a3de7a82a9c14a70426a7fda68a26f41a.tar.gz";
-      sha256 = "17nhnxj7lg92yb8ngylmqd2ly2vkgi0mg6h5pnhgn4w4mxs17rly";
+      url = "https://github.com/input-output-hk/haskell.nix/archive/f78841c2d05c6c686d3888131104360944464dc2.tar.gz";
+      sha256 = "1zwhskx9drd0266kcrxf5vzcgs9vfiiibzkc2h3yarfb2xl7185q";
     }
 , nixpkgs ? (import haskellNixSrc {}).sources.nixpkgs-default
 , pkgs ? import nixpkgs (import haskellNixSrc {}).nixpkgsArgs
@@ -29,23 +29,7 @@ let
 in
   project // {
     shell = project.shellFor {
-      buildInputs = [ (pkgs.haskell-nix.hackage-package { name = "cabal-install"; version = "3.2.0.0";
-    modules = [{
-     nonReinstallablePkgs= [ "rts" "ghc-heap" "ghc-prim" "integer-gmp" "integer-simple" "base"
-      "deepseq" "array" "ghc-boot-th" "pretty" "template-haskell"
-      # ghcjs custom packages
-      "ghcjs-prim" "ghcjs-th"
-      "ghc-boot"
-      "ghc" "Win32" "array" "binary" "bytestring" "containers"
-      "directory" "filepath" "ghc-boot" "ghc-compact" "ghc-prim"
-      # "ghci" "haskeline"
-      "hpc"
-      "mtl" "parsec" "process" "text" "time" "transformers"
-      "unix" "xhtml"
-      # "stm" "terminfo"
-     ];
-    }];
-      }).components.exes.cabal ];
+      tools = { cabal = "3.2.0.0"; };
     };
   }
 

--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,51 @@
 { haskellNixSrc ? builtins.fetchTarball {
-      url = "https://github.com/input-output-hk/haskell.nix/archive/a84e3b55c642e7aec57c9677158cf446d90e9759.tar.gz";
-      sha256 = "0qnchf0f8d5k6363mcrqv936wz6zljs06bjvg1i6xmkg31bdj48m";
+      url = "https://github.com/input-output-hk/haskell.nix/archive/fc31134a3de7a82a9c14a70426a7fda68a26f41a.tar.gz";
+      sha256 = "17nhnxj7lg92yb8ngylmqd2ly2vkgi0mg6h5pnhgn4w4mxs17rly";
     }
-, nixpkgs ? haskellNixSrc + "/nixpkgs"
-, pkgs ? import nixpkgs (import haskellNixSrc)
+, nixpkgs ? (import haskellNixSrc {}).sources.nixpkgs-default
+, pkgs ? import nixpkgs (import haskellNixSrc {}).nixpkgsArgs
 , haskellCompiler ? "ghc865"
 }:
-  pkgs.haskell-nix.cabalProject {
-    src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };
+let
+  project = pkgs.haskell-nix.cabalProject {
+    src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; name = "nix-tools"; };
     ghc = pkgs.haskell-nix.compiler.${haskellCompiler};
+    modules = [{
+     nonReinstallablePkgs= [ "rts" "ghc-heap" "ghc-prim" "integer-gmp" "integer-simple" "base"
+      "deepseq" "array" "ghc-boot-th" "pretty" "template-haskell"
+      # ghcjs custom packages
+      "ghcjs-prim" "ghcjs-th"
+      "ghc-boot"
+      "ghc" "Win32" "array" "binary" "bytestring" "containers"
+      "directory" "filepath" "ghc-boot" "ghc-compact" "ghc-prim"
+      # "ghci" "haskeline"
+      "hpc"
+      "mtl" "parsec" "process" "text" "time" "transformers"
+      "unix" "xhtml"
+      # "stm" "terminfo"
+     ];
+    }];
+  };
+in
+  project // {
+    shell = project.shellFor {
+      buildInputs = [ (pkgs.haskell-nix.hackage-package { name = "cabal-install"; version = "3.2.0.0";
+    modules = [{
+     nonReinstallablePkgs= [ "rts" "ghc-heap" "ghc-prim" "integer-gmp" "integer-simple" "base"
+      "deepseq" "array" "ghc-boot-th" "pretty" "template-haskell"
+      # ghcjs custom packages
+      "ghcjs-prim" "ghcjs-th"
+      "ghc-boot"
+      "ghc" "Win32" "array" "binary" "bytestring" "containers"
+      "directory" "filepath" "ghc-boot" "ghc-compact" "ghc-prim"
+      # "ghci" "haskeline"
+      "hpc"
+      "mtl" "parsec" "process" "text" "time" "transformers"
+      "unix" "xhtml"
+      # "stm" "terminfo"
+     ];
+    }];
+      }).components.exes.cabal ];
+    };
   }
 

--- a/hackage2nix/Main.hs
+++ b/hackage2nix/Main.hs
@@ -6,7 +6,7 @@ module Main where
 import           Cabal2Nix
 import           Control.Applicative                      ( liftA2 )
 import           Control.Monad.Trans.State.Strict
-import           Crypto.Hash.SHA256                       ( hashlazy )
+import           Crypto.Hash.SHA256                       ( hash )
 import           Data.Aeson
 import           Data.Aeson.Types                         ( Pair )
 import           Data.Aeson.Encode.Pretty
@@ -69,10 +69,10 @@ main = do
   createDirectoryIfMissing False (out </> "hackage")
 
   for_ cabalFiles $ \(cabalFile, pname, path) -> do
-    gpd <- cabal2nix False MinimalDetails Nothing $ InMemory Nothing pname $ BL.toStrict cabalFile
+    gpd <- cabal2nix False MinimalDetails Nothing $ InMemory Nothing pname $ cabalFile
     writeFile (out </> path) $ show $ prettyNix gpd
 
-type GPDWriter = State (Seq (BL.ByteString, String, FilePath))
+type GPDWriter = State (Seq (BS.ByteString, String, FilePath))
 
 newtype ApplicativeMonoid f a = ApplicativeMonoid { unApplicativeMonoid :: f a }
 instance (Applicative f, Semigroup a) => Sem.Semigroup (ApplicativeMonoid f a) where
@@ -112,7 +112,7 @@ version2json pname vnum (U.VersionData { U.cabalFileRevisions, U.metaFile }) =
 revBindingJson
   :: PackageName
   -> Version
-  -> BL.ByteString
+  -> BS.ByteString
   -> Integer
   -> GPDWriter (Text, Value)
 revBindingJson pname vnum cabalFile revNum = do
@@ -123,7 +123,7 @@ revBindingJson pname vnum cabalFile revNum = do
       revName     = "r" <> fromString (show revNum)
       revPath     = "." </> "hackage" </> qualifiedName <.> "nix"
       prettyPname = fromPretty pname
-      cabalHash   = Base16.encode $ hashlazy cabalFile
+      cabalHash   = Base16.encode $ hash cabalFile
   modify' $ mappend $ Seq.singleton
     (cabalFile, prettyPname ++ ".cabal", revPath)
   return $ revName .= object

--- a/lib/Stack2nix.hs
+++ b/lib/Stack2nix.hs
@@ -28,7 +28,8 @@ import Data.Text.Prettyprint.Doc.Render.Text (hPutDoc)
 import Distribution.Types.PackageId (PackageIdentifier(..))
 import Distribution.Nixpkgs.Fetch (DerivationSource(..), Source(..), Hash(..), fetch)
 import Distribution.Simple.Utils (shortRelativePath)
-import Distribution.Text (Text(..), simpleParse)
+import Distribution.Text (simpleParse)
+import Distribution.Pretty (Pretty(..))
 
 import Cabal2Nix hiding (Git)
 import qualified Cabal2Nix as C2N
@@ -112,8 +113,8 @@ extraDeps2nix pkgs =
      | (PackageIdentifier pkg ver, (Just (Right revNo))) <- extraDeps ]
   where parsePackageIdentifier :: String -> Maybe PackageIdentifier
         parsePackageIdentifier = simpleParse
-        toText :: Text a => a -> T.Text
-        toText = fromString . show . disp
+        toText :: Pretty a => a -> T.Text
+        toText = fromString . show . pretty
 
 -- | Converts 'PackageFlags' into @{ packageName = { flags = { flagA = BOOL; flagB = BOOL; }; }; }@
 flags2nix :: PackageFlags -> [Binding NExpr]

--- a/lts2nix/Main.hs
+++ b/lts2nix/Main.hs
@@ -6,7 +6,7 @@ module Main where
 import System.Environment (getArgs,lookupEnv)
 import Data.Maybe (fromMaybe)
 
-import Distribution.Text (disp)
+import Distribution.Pretty (pretty)
 
 import Data.Yaml (decodeFileEither)
 
@@ -70,9 +70,9 @@ lts2plan compilerPackagesMap lts = Plan { packages, compilerVersion, compilerPac
       let (pkg, rev) = case (parsePackageIdentifier . Text.unpack $ v ^. key "hackage" . _String) of
                           Just p -> p
                           _ -> error $ "failed to parse: " ++ Text.unpack (v ^. key "hackage" . _String)
-          name = Text.pack (show (disp (pkgName pkg)))
+          name = Text.pack (show (pretty (pkgName pkg)))
       in (name, Just $ Package
-        { packageVersion = Text.pack (show (disp (pkgVersion pkg)))
+        { packageVersion = Text.pack (show (pretty (pkgVersion pkg)))
         , packageRevision = case rev of
             Just (Left sha) -> Just $ Text.pack sha
             _               -> Nothing

--- a/nix-tools.cabal
+++ b/nix-tools.cabal
@@ -29,7 +29,7 @@ library
                      , Stack2nix.Project
                      , Stack2nix.Stack
   build-depends:       base >=4 && <4.13
-                     , Cabal >= 2.4 && <3
+                     , Cabal >= 3.2 && <3.3
                      , aeson
                      , aeson-pretty
                      , base16-bytestring

--- a/nix-tools.cabal
+++ b/nix-tools.cabal
@@ -28,7 +28,7 @@ library
                      , Stack2nix.External.Resolve
                      , Stack2nix.Project
                      , Stack2nix.Stack
-  build-depends:       base >=4 && <4.13
+  build-depends:       base >=4 && <4.15
                      , Cabal >= 3.2 && <3.3
                      , aeson
                      , aeson-pretty
@@ -41,7 +41,7 @@ library
                      , directory
                      , extra
                      , filepath
-                     , hnix
+                     , hnix >= 0.6.5
                      , hpack
                      , http-client
                      , http-client-tls
@@ -61,7 +61,7 @@ library
 executable cabal-to-nix
   ghc-options:         -Wall
   main-is:             Main.hs
-  build-depends:       base >=4 && <4.13
+  build-depends:       base >=4 && <4.15
                      , transformers
                      , bytestring
                      , hpack
@@ -77,7 +77,7 @@ executable cabal-to-nix
 executable hashes-to-nix
   ghc-options:         -Wall
   main-is:             Main.hs
-  build-depends:       base >=4 && <4.13
+  build-depends:       base >=4 && <4.15
                      , hnix
                      , nix-tools
                      , data-fix
@@ -98,7 +98,7 @@ executable plan-to-nix
                      , Plan2Nix.CLI
                      , Plan2Nix.Project
                      , Plan2Nix.Plan
-  build-depends:       base >=4 && <4.13
+  build-depends:       base >=4 && <4.15
                      , nix-tools
                      , hnix
                      , Cabal >= 2.4
@@ -122,7 +122,7 @@ executable plan-to-nix
 executable hackage-to-nix
   ghc-options:         -Wall
   main-is:             Main.hs
-  build-depends:       base >=4 && <4.13
+  build-depends:       base >=4 && <4.15
                      , nix-tools
                      , hackage-db
                      , hnix
@@ -144,7 +144,7 @@ executable hackage-to-nix
 executable lts-to-nix
   ghc-options:         -Wall
   main-is:             Main.hs
-  build-depends:       base >=4 && <4.13
+  build-depends:       base >=4 && <4.15
                      , nix-tools
                      , hnix
                      , yaml
@@ -163,7 +163,7 @@ executable lts-to-nix
 executable stack-to-nix
   ghc-options:         -Wall
   main-is:             Main.hs
-  build-depends:       base >=4 && <4.13
+  build-depends:       base >=4 && <4.15
                      , nix-tools
   hs-source-dirs:      stack2nix
   default-language:    Haskell2010
@@ -184,7 +184,7 @@ executable truncate-index
 executable stack-repos
   ghc-options:         -Wall
   main-is:             Main.hs
-  build-depends:       base >=4 && <4.13
+  build-depends:       base >=4 && <4.15
                      , nix-tools
   hs-source-dirs:      stack-repos
   default-language:    Haskell2010
@@ -192,7 +192,7 @@ executable stack-repos
 executable cabal-name
   ghc-options:         -Wall
   main-is:             Main.hs
-  build-depends:       base >=4 && <4.13
+  build-depends:       base >=4 && <4.15
                      , nix-tools
   hs-source-dirs:      cabal-name
   default-language:    Haskell2010

--- a/nix-tools.cabal
+++ b/nix-tools.cabal
@@ -41,6 +41,9 @@ library
                      , directory
                      , extra
                      , filepath
+-- Needs https://github.com/input-output-hk/iohk-nix/commit/6a8c29117eff36ce975e02e01efc8b25d93fcb90#diff-6fb0c6517b547a8baf082d5d2d604842
+-- to work with the data-dir issues when building components.
+-- This commit is included since 0.6.5.
                      , hnix >= 0.6.5
                      , hpack
                      , http-client

--- a/plan2nix/Plan2Nix.hs
+++ b/plan2nix/Plan2Nix.hs
@@ -240,10 +240,11 @@ value2plan plan = Plan { packages, extras, compilerVersion, compilerPackages }
 
 defaultNixContents = unlines $
   [ "{ haskellNixSrc ? builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz"
-  , ", nixpkgs ? (import (haskellNixSrc + \"/nixpkgs\")).nixpkgs-default }:"
+  , ", haskellNix ? import haskellNixSrc {}"
+  , ", nixpkgs ? haskellNix.sources.nixpkgs-default }:"
   , ""
   , "let"
-  , "  pkgs = import nixpkgs (import haskellNixSrc {}).nixpkgsArgs;"
+  , "  pkgs = import nixpkgs haskellNix.nixpkgsArgs;"
   , ""
   , "  pkgSet = pkgs.haskell-nix.mkCabalProjectPkgSet {"
   , "    plan-pkgs = import ./pkgs.nix;"

--- a/plan2nix/Plan2Nix.hs
+++ b/plan2nix/Plan2Nix.hs
@@ -240,10 +240,10 @@ value2plan plan = Plan { packages, extras, compilerVersion, compilerPackages }
 
 defaultNixContents = unlines $
   [ "{ haskellNixSrc ? builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz"
-  , ", nixpkgs ? haskellNixSrc + \"/nixpkgs\" }:"
+  , ", nixpkgs ? (import (haskellNixSrc + \"/nixpkgs\")).nixpkgs-default }:"
   , ""
   , "let"
-  , "  pkgs = import nixpkgs (import haskellNixSrc);"
+  , "  pkgs = import nixpkgs (import haskellNixSrc {}).nixpkgsArgs;"
   , ""
   , "  pkgSet = pkgs.haskell-nix.mkCabalProjectPkgSet {"
   , "    plan-pkgs = import ./pkgs.nix;"

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,3 @@
 { haskellCompiler ? "ghc865" }:
-(import ./. { inherit haskellCompiler; }).shells.ghc
+(import ./. { inherit haskellCompiler; }).shell
     


### PR DESCRIPTION
We'll need to support Cabal-3.2 to that hackage.nix properly updated, and we can parse `.cabal` files using new cabal features/formats. This requires to upgrade `nix-tools` to build against the `Cabal-3.2`.