### PR TITLE
externalize errors msg functions to hsPkgs provided by haskell.nix

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -17,7 +17,7 @@ cabal new-configure
 
 echo
 echo "+++ Run stable version of plan-to-nix"
-nix-build -E '(let haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}; in (import haskellNix.sources.nixpkgs-default haskellNix.nixpkgsArgs).haskell-nix.nix-tools)' -o nt
+nix build '(let haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}; in (import haskellNix.sources.nixpkgs-default haskellNix.nixpkgsArgs).haskell-nix.nix-tools)' -o nt
 ./nt/bin/plan-to-nix --output .buildkite/nix1 --plan-json dist-newstyle/cache/plan.json
 
 # Replace currently broken plan-to-nix output

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -17,7 +17,7 @@ cabal new-configure
 
 echo
 echo "+++ Run stable version of plan-to-nix"
-nix build '(let haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}; in (import haskellNix.sources.nixpkgs-default haskellNix.nixpkgsArgs).haskell-nix.nix-tools)' -o nt
+nix-build '(let haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}; in (import haskellNix.sources.nixpkgs-default haskellNix.nixpkgsArgs).haskell-nix.nix-tools)' -o nt
 ./nt/bin/plan-to-nix --output .buildkite/nix1 --plan-json dist-newstyle/cache/plan.json
 
 # Replace currently broken plan-to-nix output

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -17,7 +17,7 @@ cabal new-configure
 
 echo
 echo "+++ Run stable version of plan-to-nix"
-nix-build '(let haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}; in (import haskellNix.sources.nixpkgs-default haskellNix.nixpkgsArgs).haskell-nix.nix-tools)' -o nt
+nix-build -E '(let haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}; in (import haskellNix.sources.nixpkgs-default haskellNix.nixpkgsArgs).haskell-nix.nix-tools)' -o nt
 ./nt/bin/plan-to-nix --output .buildkite/nix1 --plan-json dist-newstyle/cache/plan.json
 
 # Replace currently broken plan-to-nix output

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 { haskellNixSrc ? builtins.fetchTarball {
-      url = "https://github.com/input-output-hk/haskell.nix/archive/f78841c2d05c6c686d3888131104360944464dc2.tar.gz";
-      sha256 = "1zwhskx9drd0266kcrxf5vzcgs9vfiiibzkc2h3yarfb2xl7185q";
+      url = "https://github.com/input-output-hk/haskell.nix/archive/3178c84e162dadc6e740eef3d56391d3a0f1c228.tar.gz";
+      sha256 = "0bwgibp8vaavnqxzw6iphhzrcr7mr59fgm9pa05csbx1paxzirim";
     }
 , nixpkgs ? (import haskellNixSrc {}).sources.nixpkgs-default
 , pkgs ? import nixpkgs (import haskellNixSrc {}).nixpkgsArgs

--- a/lib/Cabal2Nix.hs
+++ b/lib/Cabal2Nix.hs
@@ -47,9 +47,10 @@ data Src
   | Git String String (Maybe String) (Maybe String)
   deriving Show
 
-pkgs, hsPkgs, pkgconfPkgs, flags :: Text
+pkgs, hsPkgs, pkgsErrors, pkgconfPkgs, flags :: Text
 pkgs   = "pkgs"
 hsPkgs = "hsPkgs"
+pkgsErrors = "pkgs-errors"
 pkgconfPkgs = "pkgconfPkgs"
 flags  = "flags"
 
@@ -97,7 +98,7 @@ cabal2nix isLocal fileDetails src = \case
         (_, Right desc) -> pure desc
 
 gpd2nix :: Bool -> CabalDetailLevel -> Maybe Src -> Maybe NExpr -> GenericPackageDescription -> NExpr
-gpd2nix isLocal fileDetails src extra gpd = mkLets errorFunctions $ mkFunction args $ toNixGenericPackageDescription isLocal fileDetails gpd $//? (toNix <$> src) $//? extra
+gpd2nix isLocal fileDetails src extra gpd = mkFunction args $ toNixGenericPackageDescription isLocal fileDetails gpd $//? (toNix <$> src) $//? extra
   where args :: Params NExpr
         args = mkParamset [ ("system", Nothing)
                           , ("compiler", Nothing)
@@ -106,58 +107,6 @@ gpd2nix isLocal fileDetails src extra gpd = mkLets errorFunctions $ mkFunction a
                           , (hsPkgs, Nothing)
                           , (pkgconfPkgs, Nothing)]
                           True
-
-errorFunctions :: [Binding NExpr]
-errorFunctions =
-  [ buildDepError $= mkFunction "pkg" (mkThrow $
-      Fix $ NStr $ Indented 0
-          [ Plain "The Haskell package set does not contain the package: "
-          , Antiquoted "pkg"
-          , Plain " (build dependency).\n\n"
-          , Plain haskellUpdateSnippet
-          ])
-  , sysDepError $= mkFunction "pkg" (mkThrow $
-      Fix $ NStr $ Indented 0
-          [ Plain "The Nixpkgs package set does not contain the package: "
-          , Antiquoted "pkg"
-          , Plain " (system dependency).\n\n"
-          , Plain systemUpdateSnippet
-          ])
-  , pkgConfDepError $= mkFunction "pkg" (mkThrow $
-      Fix $ NStr $ Indented 0
-          [ Plain "The pkg-conf packages does not contain the package: "
-          , Antiquoted "pkg"
-          , Plain " (pkg-conf dependency).\n\n"
-          , Plain "You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found."
-          ])
-  , exeDepError $= mkFunction "pkg" (mkThrow $
-      Fix $ NStr $ Indented 0
-          [ Plain "The local executable components do not include the component: "
-          , Antiquoted "pkg"
-          , Plain " (executable dependency)."
-          ])
-  , legacyExeDepError $= mkFunction "pkg" (mkThrow $
-      Fix $ NStr $ Indented 0
-          [ Plain "The Haskell package set does not contain the package: "
-          , Antiquoted "pkg"
-          , Plain " (executable dependency).\n\n"
-          , Plain haskellUpdateSnippet
-          ])
-  , buildToolDepError $= mkFunction "pkg" (mkThrow $
-      Fix $ NStr $ Indented 0
-          [ Plain "Neither the Haskell package set or the Nixpkgs package set contain the package: "
-          , Antiquoted "pkg"
-          , Plain " (build tool dependency).\n\n"
-          , Plain "If this is a system dependency:\n"
-          , Plain systemUpdateSnippet
-          , Plain "\n\n"
-          , Plain "If this is a Haskell dependency:\n"
-          , Plain haskellUpdateSnippet
-          ])
-  ]
-  where
-    systemUpdateSnippet = "You may need to augment the system package mapping in haskell.nix so that it can be found."
-    haskellUpdateSnippet = "If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix."
 
 class IsComponent a where
   getBuildInfo :: a -> BuildInfo
@@ -326,22 +275,22 @@ toNixGenericPackageDescription isLocal detailLevel gpd = mkNonRecSet
 -- WARNING: these use functions bound at he top level in the GPD expression, they won't work outside it
 
 instance ToNixExpr Dependency where
-  toNix d = selectOr (mkSym hsPkgs) (mkSelector $ quoted pkg) (mkSym buildDepError @@ mkStr pkg)
+  toNix d = selectOr (mkSym hsPkgs) (mkSelector $ quoted pkg) (mkSym hsPkgs @. pkgsErrors @. buildDepError @@ mkStr pkg)
     where
       pkg = fromString . show . pretty . depPkgName $ d
 
 instance ToNixExpr SysDependency where
-  toNix d = selectOr (mkSym pkgs) (mkSelector $ quoted pkg) (mkSym sysDepError @@ mkStr pkg)
+  toNix d = selectOr (mkSym pkgs) (mkSelector $ quoted pkg) (mkSym hsPkgs @. pkgsErrors @. sysDepError @@ mkStr pkg)
     where
       pkg = fromString . unSysDependency $ d
 
 instance ToNixExpr PkgconfigDependency where
-  toNix (PkgconfigDependency name _versionRange) = selectOr (mkSym pkgconfPkgs) (mkSelector $ quoted pkg) (mkSym pkgConfDepError @@ mkStr pkg)
+  toNix (PkgconfigDependency name _versionRange) = selectOr (mkSym pkgconfPkgs) (mkSelector $ quoted pkg) (mkSym hsPkgs @. pkgsErrors @. pkgConfDepError @@ mkStr pkg)
     where
       pkg = fromString . unPkgconfigName $ name
 
 instance ToNixExpr ExeDependency where
-  toNix (ExeDependency pkgName' _unqualCompName _versionRange) = selectOr (mkSym "exes") (mkSelector $ pkg) (mkSym exeDepError @@ mkStr pkg)
+  toNix (ExeDependency pkgName' _unqualCompName _versionRange) = selectOr (mkSym "exes") (mkSelector $ pkg) (mkSym hsPkgs @. pkgsErrors @. exeDepError @@ mkStr pkg)
     where
       pkg = fromString . show . pretty $ pkgName'
 
@@ -351,13 +300,13 @@ instance ToNixExpr BuildToolDependency where
       -- is reolved use something like:
       -- [nix| hsPkgs.buildPackages.$((pkgName)) or pkgs.buildPackages.$((pkgName)) ]
       selectOr (mkSym hsPkgs) buildPackagesDotName
-        (selectOr (mkSym pkgs) buildPackagesDotName (mkSym buildToolDepError @@ mkStr pkg))
+        (selectOr (mkSym pkgs) buildPackagesDotName (mkSym hsPkgs @. pkgsErrors @. buildToolDepError @@ mkStr pkg))
     where
       pkg = fromString . show . pretty $ pkgName'
       buildPackagesDotName = mkSelector "buildPackages" <> mkSelector pkg
 
 instance ToNixExpr LegacyExeDependency where
-  toNix (LegacyExeDependency name _versionRange) = selectOr (mkSym hsPkgs) (mkSelector $ quoted pkg) (mkSym legacyExeDepError @@ mkStr pkg)
+  toNix (LegacyExeDependency name _versionRange) = selectOr (mkSym hsPkgs) (mkSelector $ quoted pkg) (mkSym hsPkgs @. pkgsErrors @. legacyExeDepError @@ mkStr pkg)
     where
       pkg = fromString name
 
@@ -422,5 +371,3 @@ boolTreeToNix (CondNode True _c bs) =
 
 instance ToNixBinding Flag where
   toNixBinding (MkFlag name _desc def _manual) = (fromString . show . pretty $ name) $= mkBool def
-
-

--- a/lib/Cabal2Nix.hs
+++ b/lib/Cabal2Nix.hs
@@ -100,7 +100,7 @@ cabal2nix isLocal fileDetails src = \case
 
 gpd2nix :: Bool -> CabalDetailLevel -> Maybe Src -> Maybe NExpr -> GenericPackageDescription -> NExpr
 gpd2nix isLocal fileDetails src extra gpd =
-  mkLets errorFunctions $ mkFunction args $ toNixGenericPackageDescription isLocal fileDetails gpd
+  mkFunction args $ toNixGenericPackageDescription isLocal fileDetails gpd
     $//? (srcToNix (package $ packageDescription gpd) <$> src)
     $//? extra
   where args :: Params NExpr

--- a/lib/Cabal2Nix.hs
+++ b/lib/Cabal2Nix.hs
@@ -110,7 +110,7 @@ gpd2nix isLocal fileDetails src extra gpd =
                           , (pkgs, Nothing)
                           , (hsPkgs, Nothing)
                           , (pkgconfPkgs, Nothing)
-                          , (errorHandler, Nothing)]
+                          , (errorHandler, Nothing)
                           , ("config", Nothing)]
                           True
 


### PR DESCRIPTION
 to save some disk space: ~30% uncompressed, ~15% compressed.
Should also ease maintenance of those functions.
Sister PR: https://github.com/input-output-hk/haskell.nix/pull/588



Btw, is there any point to pushing the hackage index (`index.tar.gz` ~ 85Mo) to the hackage.nix repo?