### PR TITLE
Fix hackage-to-nix missing old hackage revisions

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,8 +5,8 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/hamishmack/hackage-db.git
-    tag: f1f528db7b02d90e9953297c716de5e046f3570f
-    --sha256: 0j86xkpndxn41sy2mchx029zc3isaxh61hdvnakpiflkcmfaji1w
+    tag: 3f12730c0d6092efce142cad87264e7b7eb2b05a
+    --sha256: 13nl8swdd3g1rh14f29v6nhnzaxgc8l70vs6hviw8qgdpbxvhs45
 
 -- hnix requires hnix-store-core < 0.2, however hnix-store-core-0.1 breaks
 -- plan construction.

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 { haskellNixSrc ? builtins.fetchTarball {
-      url = "https://github.com/input-output-hk/haskell.nix/archive/3178c84e162dadc6e740eef3d56391d3a0f1c228.tar.gz";
-      sha256 = "0bwgibp8vaavnqxzw6iphhzrcr7mr59fgm9pa05csbx1paxzirim";
+      url = "https://github.com/input-output-hk/haskell.nix/archive/61b1c8a06c74a83c0d2dc7d937d8daa6b32b2a2f.tar.gz";
+      sha256 = "1vi8is7h85sb8acymjcnkjm39fp5pal2wq9p7zdv5cmillzs2sza";
     }
 , nixpkgs ? (import haskellNixSrc {}).sources.nixpkgs-default
 , pkgs ? import nixpkgs (import haskellNixSrc {}).nixpkgsArgs


### PR DESCRIPTION
When updating hackage-db cabal-revisions branch [this append](https://github.com/peti/hackage-db/pull/9/files#diff-7968cd26685b48210552ee1d525cfec0R87) was left out. It is added [here](https://github.com/hamishmack/hackage-db/commit/3f12730c0d6092efce142cad87264e7b7eb2b05a) and this PR updates nix-tools.