### PR TITLE
Fix `@rev:<n>` extra-deps specification not working

### DIFF
--- a/lib/Stack2nix/Stack.hs
+++ b/lib/Stack2nix/Stack.hs
@@ -163,7 +163,7 @@ revSuffix :: ParsecParser CabalRev
 revSuffix = string "@rev:" *> (CabalRev . read <$> some (satisfy (`elem` ['0'..'9'])))
 
 suffix :: ParsecParser (Maybe (Either Sha256 CabalRev))
-suffix = option Nothing (Just <$> ((Left <$> sha256Suffix) <|> (Right <$> revSuffix)))
+suffix = option Nothing (Just <$> (try (Left <$> sha256Suffix) <|> (Right <$> revSuffix)))
 
 pkgIndex :: ParsecParser Dependency
 pkgIndex = PkgIndex <$> parsec <*> suffix <* eof


### PR DESCRIPTION
Previously the commutative [`(+++)`](https://hackage.haskell.org/package/Cabal-2.4.1.0/docs/Distribution-Compat-ReadP.html#v:-43--43--43-) operator was used, but with e04dbd4ea7cb7eeb00acdbe4d4e1b7b66dcb19d7 the [`(<|>)`](https://hackage.haskell.org/package/Cabal-3.2.0.0/docs/Distribution-Compat-Prelude-Internal.html#v:-60--124--62-) operator is used instead, which is only associative, but not commutative for the parser used.

This PR fixes this with a [`try`](https://hackage.haskell.org/package/Cabal-3.2.0.0/docs/Distribution-Compat-Parsing.html#v:try) on the first branch, such that the second one gets used if the first one fails (with backtracking).

A better fix would be possible with something like `char '@' *> some (satisfy isAlpha) <* char ':'` and deciding the branch based on the read string, but for simplicity I didn't bother with this.

Without this change, you get an error like this if you try to specify a revision:
```
stack-to-nix: /home/.../bytestring-trie-0.2.5.0@rev:1:
  getDirectoryContents:openDirStream: does not exist (No such file or directory)
```

which is very similar to the one in https://github.com/input-output-hk/haskell.nix/issues/550, and indeed both this PR and the fix to the package I suggested in https://github.com/input-output-hk/haskell.nix/issues/550#issuecomment-627466107 are necessary to make this work ultimately.

Ping @angerman @hamishmack @maksbotan 

PS: This is not the only place the `<|>` operator is used, you might want to verify that the other uses work too.