### PR TITLE
Add "branch" information for stack-repos

### DIFF
--- a/lib/Stack2nix.hs
+++ b/lib/Stack2nix.hs
@@ -159,7 +159,7 @@ packages2nix args pkgs =
                     writeDoc nixFile =<<
                       prettyNix <$> cabal2nix True (argDetailLevel args) src cabalFile
                     return (fromString pkg, fromString pkg $= mkPath False nix)
-       (DVCS (Git url rev) _ subdirs) ->
+       (DVCS (Git url rev) _ _ subdirs) ->
          do hits <- forM subdirs $ \subdir -> liftIO $ cacheHits (argCacheFile args) url rev subdir
             let generateBindings =
                   fetch (cabalFromPath url rev subdirs)

--- a/lib/Stack2nix/Stack.hs
+++ b/lib/Stack2nix/Stack.hs
@@ -118,7 +118,7 @@ instance Parsec CabalRev where
 data Dependency
   = PkgIndex PackageIdentifier (Maybe (Either Sha256 CabalRev)) -- ^ overridden package in the stackage index
   | LocalPath String -- ^ Some local package (potentially overriding a package in the index as well)
-  | DVCS Location (Maybe Sha256) [FilePath] -- ^ One or more packages fetched from git or similar.
+  | DVCS Location (Maybe Sha256) (Maybe String) [FilePath] -- ^ One or more packages fetched from git or similar.
   -- TODO: Support archives.
   -- | Archive ...
   deriving (Show)
@@ -226,6 +226,7 @@ instance FromJSON Dependency where
           parseDVCS = withObject "DVCS" $ \o -> DVCS
             <$> (o .: "location" <|> parseJSON p)
             <*> o .:? "nix-sha256" .!= Nothing
+            <*> o .:? "nix-branch" .!= Nothing
             <*> o .:? "subdirs" .!= ["."]
 
           -- drop trailing slashes. Nix doesn't like them much;

--- a/lib/StackRepos.hs
+++ b/lib/StackRepos.hs
@@ -24,6 +24,7 @@ data SourceRepos = SourceRepos
   { url     :: String
   , rev     :: String
   , sha256  :: Maybe String
+  , branch  :: Maybe String
   , subdirs :: [FilePath]
   } deriving (Show, Eq, Ord, Generic)
 
@@ -41,6 +42,6 @@ stack2nix :: Args -> Stack -> IO ()
 stack2nix args (Stack _ _ pkgs _ _) =
   LBS.writeFile "repos.json" $ encodePretty (
     pkgs >>= (\case
-       (DVCS (Git url rev) sha256 subdirs) ->
-         [SourceRepos { url, rev, sha256, subdirs }]
+       (DVCS (Git url rev) sha256 branch subdirs) ->
+         [SourceRepos { url, rev, sha256, branch, subdirs }]
        _ -> []))


### PR DESCRIPTION
The builtins.fetchGit used by haskell.nix clones only the subset of a
repository corresponding to HEAD. So if we have a workflow that has a
branch "development" as HEAD, but the stack.yaml only targets commits
from "master", then it will be unable to fetch any commit.

This commit is the first part of the job: it parses an optional
nix-branch information from the stack.yml and exposes it in the json
result, that will be used by haskell.nix in a similar way as nix-sha256

The haskell.nix counterpart is submitted there: https://github.com/input-output-hk/haskell.nix/pull/1019