### PR TITLE
Use cabal-install logic for package tar.gz uri

### DIFF
--- a/nix-tools.cabal
+++ b/nix-tools.cabal
@@ -49,6 +49,7 @@ library
                      , http-client
                      , http-client-tls
                      , http-types
+                     , network-uri
                      , optparse-applicative
                      , prettyprinter
                      , process


### PR DESCRIPTION
This change uses the same logic that cabal-install uses for determining the path of a packages `.tar.gz` in a repository.